### PR TITLE
Fixed merged Automatic1111 models

### DIFF
--- a/prune.py
+++ b/prune.py
@@ -23,8 +23,10 @@ def prune(
         unet = True,
 ):
     sd = checkpoint
+    nested_sd = False
     if 'state_dict' in sd:
         sd = sd['state_dict']
+        nested_sd = True
     sd_pruned = dict()
     for k in sd:
         cp = unet and k.startswith('model.diffusion_model.')
@@ -38,7 +40,10 @@ def prune(
                 if k_ema in sd:
                     k_in = k_ema
             sd_pruned[k] = sd[k_in].half() if fp16 else sd[k_in]
-    return { 'state_dict': sd_pruned }
+    if nested_sd:
+        return { 'state_dict': sd_pruned }
+    else:
+        return sd_pruned
 
 def main(args):
     from argparse import ArgumentParser

--- a/prune.py
+++ b/prune.py
@@ -22,7 +22,9 @@ def prune(
         depth = True,
         unet = True,
 ):
-    sd = checkpoint['state_dict']
+    sd = checkpoint
+    if 'state_dict' in sd:
+        sd = sd['state_dict']
     sd_pruned = dict()
     for k in sd:
         cp = unet and k.startswith('model.diffusion_model.')


### PR DESCRIPTION
The following error is shown when attempting to prune Automatic1111 merged models:

`KeyError: 'state_dict'`

This code was borrowed from InvokeAI's fix to also allow working with Automatic1111 merged models.